### PR TITLE
Add tag to video to prevent video feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# rider directory
+.idea
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/boulderlog/Views/Climb/Create.cshtml
+++ b/boulderlog/Views/Climb/Create.cshtml
@@ -77,7 +77,7 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <video id="video" width="250" height="250" autoplay></video>
+                <video id="video" width="250" height="250" autoplay="" playsinline=""></video>
             </div>
             <div class="modal-footer">
                 <button type="button" id="capture-image" data-bs-dismiss="modal" class="btn btn-primary">Capture</button>

--- a/boulderlog/wwwroot/js/climb-create.js
+++ b/boulderlog/wwwroot/js/climb-create.js
@@ -28,11 +28,13 @@ document.querySelector("#file-image").addEventListener('change', async function 
 
 document.querySelector("#open-camera-modal").addEventListener('click', async function () {
     let stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false });
+    let video = document.getElementById('video')
     video.srcObject = stream;
 });
 
 document.querySelector("#capture-image").addEventListener('click', async function () {
     let canvas = document.querySelector("#canvas");
+    let video = document.getElementById('video')
     canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
     video.srcObject.getTracks()[0].stop();
     $(canvas).removeClass("placeholder");


### PR DESCRIPTION
closes #18 

Adding the tag `playsinline` on the video tag will prevent the video feed from opening in a new window. This also eliminates the tiny image that appears as well. I also added a document selector for the video tag since we were technically referencing a undefined variable~

It will be worth checking the android version when this is pushed to make sure there are no side effects of this change on android devices (i don't have an android device)

Sidenote:

I was able to test localhost on my phone by enabling Developer mode on the safari advanced settings in my phone settings, then connecting to my mac, opening safari, and then going to Developer > iPhone > inspect.