### PR TITLE
Fix: Added app.Fallback to handel unknown routes

### DIFF
--- a/boulderlog/Program.cs
+++ b/boulderlog/Program.cs
@@ -141,13 +141,18 @@ namespace Boulderlog
 
             app.UseCors();
             app.UseResponseCaching();
+            app.UseAuthentication(); //To ensure that the authentication middleware is used.
             app.UseAuthorization();
 
             app.MapControllerRoute(
                 name: "default",
                 pattern: "{controller=Home}/{action=Index}/{id?}");//.RequireRateLimiting(rateLimitOptions.Policy);
             app.MapRazorPages();//.RequireRateLimiting(rateLimitOptions.Policy);
-
+            app.MapFallback(context =>
+           {
+             context.Response.Redirect("Identity/Account/Login"); //fallback route redirects to Identity/Account/Login whenever an invalid URL is accessed 
+             return Task.CompletedTask;
+           });
             app.Run();
         }
     }


### PR DESCRIPTION
Fix for handeling 404 
1) I've inserted app.UseAuthentication(); prior to app.UseAuthorization(); to make sure the authentication middleware is activated. 

2) I've included a fallback route app.MapFallback that redirects users to /Account/Login for any invalid URL requests.