### PR TITLE
Fix: Redirecting wrong urls to home and un authorized uls to login page.

### DIFF
--- a/boulderlog/Program.cs
+++ b/boulderlog/Program.cs
@@ -155,11 +155,7 @@ namespace Boulderlog
             {
                  context.Response.Redirect("/"); //Redirecting if wrong url or wrong route is added
             }
-            else if (!context.User.Identity.IsAuthenticated)
-            {
-                 context.Response.Redirect("Identity/Account/Login");
-            }
-        });
+           });
 
             app.Run();
         }

--- a/boulderlog/Program.cs
+++ b/boulderlog/Program.cs
@@ -147,6 +147,19 @@ namespace Boulderlog
                 name: "default",
                 pattern: "{controller=Home}/{action=Index}/{id?}");//.RequireRateLimiting(rateLimitOptions.Policy);
             app.MapRazorPages();//.RequireRateLimiting(rateLimitOptions.Policy);
+            app.Use(async (context, next) =>
+           {
+              await next();
+
+            if (context.Response.StatusCode == 404)
+            {
+                 context.Response.Redirect("/"); //Redirecting if wrong url or wrong route is added
+            }
+            else if (!context.User.Identity.IsAuthenticated)
+            {
+                 context.Response.Redirect("Identity/Account/Login");
+            }
+        });
 
             app.Run();
         }


### PR DESCRIPTION
If the route is valid and does not have token or authorization it will direct to login page
![image](https://github.com/nicholasbergesen/boulderlog/assets/115641501/bf107063-d09b-4162-9a4d-bf61b75401cf)

If there is no route and If you are trying to access it through URL this will  take you to home page. In you case there is no route to **climbs** only climb is valid route. Therefore when user enters **climbs** which is not a valid URL this is take you to base URL which is home page.
![image](https://github.com/nicholasbergesen/boulderlog/assets/115641501/cb8d3f76-4048-4ca6-bfaf-b09350226fcf)


Please let me know if this is something you are looking for or let me know anything else. I can amend the changes 

Closes: https://github.com/nicholasbergesen/boulderlog/issues/25